### PR TITLE
Add custom questions

### DIFF
--- a/src/clients/eventTypesClient.ts
+++ b/src/clients/eventTypesClient.ts
@@ -1,7 +1,8 @@
 import * as dotenv from 'dotenv'
 import {
   EventType, EventTypeEntity, EventTypeList, EventTypeOptions, EventTypeType,
-  Kind, PaginationEntity, PoolingType, Profile, ProfileEntity, ProfileType, Token
+  Kind, PaginationEntity, PoolingType, Profile, ProfileEntity, ProfileType, Token,
+  CustomQuestion, CustomQuestionEntity
 } from '../types'
 import { AxiosResponse } from 'axios'
 import BaseClient from './baseClient'
@@ -87,6 +88,7 @@ export default class EventTypesClient extends BaseClient {
       descriptionPlain: data.description_plain,
       descriptionHtml: data.description_html,
       profile: this.getProfile(data.profile),
+      customQuestions: this.getCustomQuestions(data.custom_questions),
       secret: data.secret
     }
   }
@@ -97,5 +99,17 @@ export default class EventTypesClient extends BaseClient {
       name: data.name,
       owner: data.owner
     }
+  }
+
+  private getCustomQuestions(data: CustomQuestionEntity[]): CustomQuestion[] {
+    return data?.map(customQuestion => ({
+      name: customQuestion.name,
+      type: customQuestion.type,
+      position: customQuestion.position,
+      enabled: customQuestion.enabled,
+      required: customQuestion.required,
+      answerChoices: customQuestion.answer_choices,
+      includeOther: customQuestion.include_other
+    } as CustomQuestion)) ?? []
   }
 }

--- a/src/types/eventTypes.ts
+++ b/src/types/eventTypes.ts
@@ -37,6 +37,26 @@ export enum EventTypeSort {
   NameDescending = 'name:desc'
 }
 
+export type CustomQuestionEntity = {
+  name: string
+  type: string
+  position: number
+  enabled: boolean
+  required: boolean
+  answer_choices: string[]
+  include_other: boolean
+}
+
+export type CustomQuestion = {
+  name: string
+  type: string
+  position: number
+  enabled: boolean
+  required: boolean
+  answerChoices: string[]
+  includeOther: boolean
+}
+
 export type EventTypeEntity = {
   uri: string
   name: string
@@ -55,6 +75,7 @@ export type EventTypeEntity = {
   description_html: string
   profile: ProfileEntity
   secret: boolean
+  custom_questions: CustomQuestionEntity[]
 }
 
 export type EventTypeList = {
@@ -80,6 +101,7 @@ export type EventType = {
   descriptionHtml: string
   profile: Profile
   secret: boolean
+  customQuestions: CustomQuestion[]
 }
 
 export type EventTypeOptions = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,8 @@ export {
   EventTypeSort,
   EventTypeType,
   Kind,
+  CustomQuestion,
+  CustomQuestionEntity,
   PoolingType,
   Profile,
   ProfileEntity,

--- a/test/clients/eventTypesClient.spec.ts
+++ b/test/clients/eventTypesClient.spec.ts
@@ -51,7 +51,8 @@ describe('.get', () => {
           name: eventTypeEntity.profile.name,
           owner: eventTypeEntity.profile.owner
         },
-        secret: eventTypeEntity.secret
+        secret: eventTypeEntity.secret,
+        customQuestions: []
       })
     })
   })
@@ -161,7 +162,8 @@ describe('.list', () => {
             name: eventTypeEntity1.profile.name,
             owner: eventTypeEntity1.profile.owner
           },
-          secret: eventTypeEntity1.secret
+          secret: eventTypeEntity1.secret,
+          customQuestions: []
         },
         {
           uri: eventTypeEntity2.uri,
@@ -184,7 +186,8 @@ describe('.list', () => {
             name: eventTypeEntity2.profile.name,
             owner: eventTypeEntity2.profile.owner
           },
-          secret: eventTypeEntity2.secret
+          secret: eventTypeEntity2.secret,
+          customQuestions: []
         },
         {
           uri: eventTypeEntity3.uri,
@@ -207,7 +210,8 @@ describe('.list', () => {
             name: eventTypeEntity3.profile.name,
             owner: eventTypeEntity3.profile.owner
           },
-          secret: eventTypeEntity3.secret
+          secret: eventTypeEntity3.secret,
+          customQuestions: []
         }
       ])
     })
@@ -254,7 +258,8 @@ describe('.list', () => {
               name: eventTypeEntity1.profile.name,
               owner: eventTypeEntity1.profile.owner
             },
-            secret: eventTypeEntity1.secret
+            secret: eventTypeEntity1.secret,
+            customQuestions: []
           }
         ])
       })
@@ -301,7 +306,8 @@ describe('.list', () => {
                 name: eventTypeEntity1.profile.name,
                 owner: eventTypeEntity1.profile.owner
               },
-              secret: eventTypeEntity1.secret
+              secret: eventTypeEntity1.secret,
+              customQuestions: []
             }
           ])
         })
@@ -348,7 +354,8 @@ describe('.list', () => {
                   name: eventTypeEntity1.profile.name,
                   owner: eventTypeEntity1.profile.owner
                 },
-                secret: eventTypeEntity1.secret
+                secret: eventTypeEntity1.secret,
+                customQuestions: []
               }
             ])
           })

--- a/test/factories/eventTypeFactory.ts
+++ b/test/factories/eventTypeFactory.ts
@@ -24,7 +24,8 @@ export default class EventTypeFactory {
         name: faker.name.firstName(),
         owner: faker.internet.url()
       },
-      secret: faker.random.boolean()
+      secret: faker.random.boolean(),
+      custom_questions: []
     }
   }
 }


### PR DESCRIPTION
Custom questions are currently not parsed by the client. This change parses and returns them. Tested with event types that both include and do not include custom questions.